### PR TITLE
Avoid processing .info files

### DIFF
--- a/src/objswap/objswap.c
+++ b/src/objswap/objswap.c
@@ -387,6 +387,17 @@ do_scan(ObjSwapInst *inst)
 			}
 		}
 
+		/* Do NOT process .info files!
+		 * Certain AmigaOS/Workbench flavors like to
+		 * make these for every file whenever the FS
+		 * is accessed. They will be read by the obj
+		 * scanner, which will crash the plugin.
+		*/
+
+		char * ext = strrchr(fname, '.');
+		if(strcmp(ext, ".info") == 0)
+			continue;
+
 		frame = parse_frame_number(
 			(const char *)fib->fib_FileName,
 			inst->baseName);


### PR DESCRIPTION
Certain configurations of AmigaOS and alternatives to Workbench like to automatically generate .info files for every file when queried, mainly for icons, with the exact same filename + the .info extension. This leads to the ObjSwap plugin trying to parse them as LightWave objects, which are invalid. When previewed, the object becomes corrupted and the plugin no longer works until the scene or program is restarted. This PR is a hotfix for the bug, allowing valid objects to be properly loaded for each frame in sequence regardless of .info file presence.