### PR TITLE
Fix recursive PBR blur reflections

### DIFF
--- a/src/pbr/pbr.c
+++ b/src/pbr/pbr.c
@@ -124,7 +124,7 @@ typedef struct {
 
 	/* Blurred Reflections */
 	int    blurReflEnabled;
-	int    blurReflSamples;  /* 4, 8, or 16 */
+	int    blurReflSamples;  /* 2, 4, or 8 */
 	int    blurReflAmount;   /* 0-100 cone spread */
 
 	/* Environment Light */
@@ -143,6 +143,8 @@ static MessageFuncs *msg;
 
 static double pow5_lut[101];
 static int pow5_ready = 0;
+/* sa->rayTrace can re-enter PBR on the ray hit; blur cones stay primary-only. */
+static int blur_trace_depth = 0;
 
 /* ----------------------------------------------------------------
  * Precompute F0 from IOR
@@ -526,7 +528,7 @@ Evaluate(PBRInst *inst, ShaderAccess *sa)
 
 	/* --- Blurred Reflections: cone-traced rays around reflection dir --- */
 	if (inst->blurReflEnabled && inst->blurReflSamples > 0
-	    && sa->rayTrace && sa->mirror > 0.001) {
+	    && blur_trace_depth == 0 && sa->rayTrace && sa->mirror > 0.001) {
 		double viewDir[3], reflDir[3], dot_vn;
 		double spread, px, py, pz;
 		double dir[3], col[3], pos[3];
@@ -535,7 +537,7 @@ Evaluate(PBRInst *inst, ShaderAccess *sa)
 		int    validSamples = 0;
 		int    i;
 
-		if (nSamp > 16) nSamp = 16;
+		if (nSamp > 8) nSamp = 8;
 		spread = inst->blurReflAmount / 200.0;
 		if (spread < 0.001) spread = 0.001;
 
@@ -555,6 +557,7 @@ Evaluate(PBRInst *inst, ShaderAccess *sa)
 		pos[1] = sa->wPos[1] + sa->wNorm[1] * 0.001;
 		pos[2] = sa->wPos[2] + sa->wNorm[2] * 0.001;
 
+		blur_trace_depth++;
 		for (i = 0; i < nSamp; i++) {
 			px = hash3d(sa->oPos[0], sa->oPos[1], sa->oPos[2],
 			            50000u + (unsigned int)i * 7919u) * spread;
@@ -575,6 +578,7 @@ Evaluate(PBRInst *inst, ShaderAccess *sa)
 			accB += col[2];
 			validSamples++;
 		}
+		blur_trace_depth--;
 
 		if (validSamples > 0) {
 			double invN = 1.0 / (double)validSamples;

--- a/tests/test_pbr_blur_guard.sh
+++ b/tests/test_pbr_blur_guard.sh
@@ -1,0 +1,25 @@
+#!/bin/sh
+set -eu
+
+src="${1:-src/pbr/pbr.c}"
+
+fail() {
+	printf '%s\n' "$1" >&2
+	exit 1
+}
+
+grep -Eq 'static[[:space:]]+int[[:space:]]+blur_trace_depth' "$src" ||
+	fail "missing static blur recursion depth guard"
+
+grep -Eq 'blur_trace_depth[[:space:]]*==[[:space:]]*0' "$src" ||
+	fail "blur path is not gated to primary shader evaluation"
+
+awk '
+	/blur_trace_depth\+\+/ { enter = NR }
+	/\(\*sa->rayTrace\)\(pos, dir, col\)/ { ray = NR }
+	/blur_trace_depth--/ { leave = NR }
+	END {
+		if (!enter || !ray || !leave || !(enter < ray && ray < leave))
+			exit 1
+	}
+' "$src" || fail "blur recursion guard does not wrap rayTrace calls"


### PR DESCRIPTION
## Summary

- Prevent PBR blurred reflection rays from recursively launching more blur cones when `sa->rayTrace()` re-enters the shader on reflected PBR surfaces.
- Cap runtime blur sample count at 8 to match the current UI and limit older saved scenes that may still contain 16 samples.
- Add a focused regression script that checks the blur recursion guard wraps the ray tracing call.

## Root Cause

`sa->rayTrace()` performs recursive shading. The PBR blur path called it for each blur sample before clearing `sa->mirror`, so rays hitting PBR/reflective surfaces could re-enter the same blur code and multiply the ray workload exponentially, making LightWave appear to hang during render.

Fixes #12

## Validation

- `sh tests/test_pbr_blur_guard.sh`
- `./build.sh clean pbr`
- Local LightWave scene smoke test reported working after the guard was added.