### PR TITLE
rename ObjSurfSwap to ObjMeshSwap

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -68,14 +68,14 @@ $(BUILD)/objswap.p: $(BUILD)/objswap.o sdk $(STUBS)
 
 objswap: $(BUILD)/objswap.p
 
-# ObjSurfSwap - Object replacement preserving base surfaces
-$(BUILD)/objsurfswap.o: $(SRC)/objsurfswap/objsurfswap.c | $(BUILD)
+# ObjMeshSwap - Object replacement preserving base surfaces
+$(BUILD)/objmeshswap.o: $(SRC)/objmeshswap/objmeshswap.c | $(BUILD)
 	$(CC) $(CFLAGS) -c -o $@ $<
 
-$(BUILD)/objsurfswap.p: $(BUILD)/objsurfswap.o sdk $(STUBS)
+$(BUILD)/objmeshswap.p: $(BUILD)/objmeshswap.o sdk $(STUBS)
 	$(call build-plugin,$@,$<)
 
-objsurfswap: $(BUILD)/objsurfswap.p
+objmeshswap: $(BUILD)/objmeshswap.p
 
 # Fresnel - Physically-based Fresnel shader
 $(BUILD)/fresnel.o: $(SRC)/fresnel/fresnel.c | $(BUILD)
@@ -151,9 +151,9 @@ toon: $(BUILD)/toon.p
 
 # ---- Targets ----
 
-all: sdk objswap objsurfswap fresnel pbr lensflare pngsaver pngloader normalmap motion toon
+all: sdk objswap objmeshswap fresnel pbr lensflare pngsaver pngloader normalmap motion toon
 
 clean:
 	rm -f $(BUILD)/*.o $(BUILD)/*.p $(SDK_LIB)/server.a $(SDK_LIB)/serv_gcc.o
 
-.PHONY: all sdk objswap objsurfswap fresnel pbr lensflare pngsaver pngloader normalmap motion toon clean
+.PHONY: all sdk objswap objmeshswap fresnel pbr lensflare pngsaver pngloader normalmap motion toon clean

--- a/README.md
+++ b/README.md
@@ -12,7 +12,7 @@ workflow, and plugin set.
 | Plugin | Class | Output | Documentation |
 |---|---|---|---|
 | ObjSwap | Object replacement | `objswap.p` | [README](src/objswap/README.md) |
-| ObjSurfSwap | Surface-preserving object replacement | `objsurfswap.p` | [README](src/objsurfswap/README.md) |
+| ObjMeshSwap | Surface-preserving object replacement | `objmeshswap.p` | [README](src/objmeshswap/README.md) |
 | Fresnel | Shader | `fresnel.p` | [README](src/fresnel/README.md) |
 | PBR | Shader | `pbr.p` | [README](src/pbr/README.md) |
 | LensFlare | Image filter | `lensflare.p` | [README](src/lensflare/README.md) |
@@ -55,7 +55,7 @@ Build a single plugin:
 
 ```bash
 ./build.sh objswap
-./build.sh objsurfswap
+./build.sh objmeshswap
 ./build.sh fresnel
 ./build.sh pbr
 ./build.sh lensflare
@@ -96,7 +96,7 @@ library patched for GCC compatibility:
 |   `-- source/
 `-- src/
     |-- objswap/
-    |-- objsurfswap/
+    |-- objmeshswap/
     |-- fresnel/
     |-- pbr/
     |-- lensflare/

--- a/src/objmeshswap/README.md
+++ b/src/objmeshswap/README.md
@@ -1,26 +1,26 @@
-# ObjSurfSwap — Surface-Preserving Object Replacement Plugin for LightWave 3D
+# ObjMeshSwap — Surface-Preserving Object Replacement Plugin for LightWave 3D
 
 Copyright (c) 2026 Dimitris Panokostas
 
-ObjSurfSwap automatically replaces objects during rendering based on frame numbers
+ObjMeshSwap automatically replaces objects during rendering based on frame numbers
 encoded in filenames. This is useful for frame-by-frame animation sequences,
 such as digital counters, flipbook-style animation, or any effect where different
 geometry is needed at specific frames.
 
-ObjSurfSwap is separate from ObjSwap. Use ObjSwap for direct object sequence
-replacement, and use ObjSurfSwap when the replacement geometry should render
+ObjMeshSwap is separate from ObjSwap. Use ObjSwap for direct object sequence
+replacement, and use ObjMeshSwap when the replacement geometry should render
 with the surface definitions from the object loaded in Layout.
 
 ## How It Works
 
 1. You load a **base object** in Layout (e.g., `digit`)
-2. You activate ObjSurfSwap on that object via **Obj Rep Plug-ins**
+2. You activate ObjMeshSwap on that object via **Obj Rep Plug-ins**
 3. The plugin scans the same directory for files matching the pattern
    `basename_N` where N is a frame number
 4. During preview or render, the object is automatically replaced with the
    correct file for each frame
 
-ObjSurfSwap preserves the surface settings from the base object file.
+ObjMeshSwap preserves the surface settings from the base object file.
 For numbered replacement objects, it creates a sidecar copy next to the source
 object with the replacement object's geometry and `SRFS` surface name list,
 but with the base object's top-level `SURF` chunks. Polygon assignments still
@@ -56,7 +56,7 @@ The plugin looks for files named `basename_N` where:
 
 ## Installation
 
-1. Copy `objsurfswap.p` to your LightWave plugins directory
+1. Copy `objmeshswap.p` to your LightWave plugins directory
 2. Run Layout and, without loading any scene or object, under Options tab click on 'Add Plug-Ins'
 3. Navigate to the directory you copied the plugin and select it.
 4. Restart Layout so that the configuration file get updated with the new plug-in entry.
@@ -69,7 +69,7 @@ The plugin looks for files named `basename_N` where:
 
 2. **Select the object** in the Objects panel.
 
-3. Click **Obj Rep Plug-ins** and select **ObjSurfSwap** from the popup menu.
+3. Click **Obj Rep Plug-ins** and select **ObjMeshSwap** from the popup menu.
 
 4. (Optional) Click **Options** to see which replacement files were found and
    their frame assignments.
@@ -96,7 +96,7 @@ The plugin looks for files named `basename_N` where:
 - **Loading any variant**: You can load any numbered variant as the base
   object (e.g., `digit_5`). The plugin will strip the `_5` suffix and
   discover all siblings automatically. When the current frame maps back to
-  that loaded object file, ObjSurfSwap keeps it loaded as-is so its own surface
+  that loaded object file, ObjMeshSwap keeps it loaded as-is so its own surface
   settings remain available for later replacements.
 
 - **Scene persistence**: The plugin settings are saved with the scene file.
@@ -111,7 +111,7 @@ The plugin looks for files named `basename_N` where:
 
 - **Surface preservation**: Keep the intended render surfaces on the base
   object. Numbered objects should use the same surface names when they need
-  those base surface settings. ObjSurfSwap may create `ObjSurfSwapCache-*.lwo`
+  those base surface settings. ObjMeshSwap may create `ObjMeshSwapCache-*.lwo`
   sidecar files beside the sequence objects; these contain replacement
   geometry plus the base object's surface definitions. Keep these with the
   project if you save scenes after previewing or rendering swapped frames.

--- a/src/objmeshswap/objmeshswap.c
+++ b/src/objmeshswap/objmeshswap.c
@@ -1,5 +1,5 @@
 /*
- * OBJSURFSWAP.C -- Layout Surface-Preserving Object Replacement Plugin
+ * OBJMESHSWAP.C -- Layout Surface-Preserving Object Replacement Plugin
  * Copyright (c) 2026 Dimitris Panokostas
  *
  * Automatically swaps objects based on frame number derived from
@@ -473,10 +473,10 @@ typedef struct {
 	int         numEntries;
 	int         capacity;
 	int         scanned;
-} ObjSurfSwapInst;
+} ObjMeshSwapInst;
 
 static int
-make_cache_path(ObjSurfSwapInst *inst, const char *src, char *dest, int destMax)
+make_cache_path(ObjMeshSwapInst *inst, const char *src, char *dest, int destMax)
 {
 	char srcHex[9];
 	int  dirLen, nameLen;
@@ -484,14 +484,14 @@ make_cache_path(ObjSurfSwapInst *inst, const char *src, char *dest, int destMax)
 	u32_to_hex(hash_string_pair(src, inst->basePath), srcHex);
 
 	dirLen = strlen(inst->baseDir);
-	nameLen = 17 + 8 + 4; /* "ObjSurfSwapCache-" + hash + ".lwo" */
+	nameLen = 17 + 8 + 4; /* "ObjMeshSwapCache-" + hash + ".lwo" */
 	if (dirLen + nameLen >= destMax) {
 		dest[0] = '\0';
 		return 0;
 	}
 
 	strcpy(dest, inst->baseDir);
-	strcat(dest, "ObjSurfSwapCache-");
+	strcat(dest, "ObjMeshSwapCache-");
 	strcat(dest, srcHex);
 	strcat(dest, ".lwo");
 
@@ -508,7 +508,7 @@ make_cache_temp_path(const char *cachePath, char *tempPath)
 }
 
 static const char *
-surface_preserved_filename(ObjSurfSwapInst *inst, const char *src)
+surface_preserved_filename(ObjMeshSwapInst *inst, const char *src)
 {
 	int made;
 
@@ -714,7 +714,7 @@ find_best_entry(FrameEntry *entries, int n, int frame)
  * ---------------------------------------------------------------- */
 
 static void
-free_entries(ObjSurfSwapInst *inst)
+free_entries(ObjMeshSwapInst *inst)
 {
 	if (inst->entries) {
 		plugin_free(inst->entries);
@@ -725,7 +725,7 @@ free_entries(ObjSurfSwapInst *inst)
 }
 
 static void
-do_scan(ObjSurfSwapInst *inst)
+do_scan(ObjMeshSwapInst *inst)
 {
 	BPTR                 lock;
 	struct FileInfoBlock *fib;
@@ -874,7 +874,7 @@ do_scan(ObjSurfSwapInst *inst)
 }
 
 static void
-scan_from_path(ObjSurfSwapInst *inst, const char *objPath)
+scan_from_path(ObjMeshSwapInst *inst, const char *objPath)
 {
 	strncpy(inst->basePath, objPath, MAX_PATH - 1);
 	inst->basePath[MAX_PATH - 1] = '\0';
@@ -896,11 +896,11 @@ scan_from_path(ObjSurfSwapInst *inst, const char *objPath)
 XCALL_(static LWInstance)
 Create(LWError *err)
 {
-	ObjSurfSwapInst *inst;
+	ObjMeshSwapInst *inst;
 
 	XCALL_INIT;
 
-	inst = (ObjSurfSwapInst *)plugin_alloc(sizeof(ObjSurfSwapInst));
+	inst = (ObjMeshSwapInst *)plugin_alloc(sizeof(ObjMeshSwapInst));
 	if (!inst)
 		return 0;
 
@@ -909,7 +909,7 @@ Create(LWError *err)
 }
 
 XCALL_(static void)
-Destroy(ObjSurfSwapInst *inst)
+Destroy(ObjMeshSwapInst *inst)
 {
 	XCALL_INIT;
 	if (!inst) return;
@@ -918,7 +918,7 @@ Destroy(ObjSurfSwapInst *inst)
 }
 
 XCALL_(static LWError)
-Copy(ObjSurfSwapInst *from, ObjSurfSwapInst *to)
+Copy(ObjMeshSwapInst *from, ObjMeshSwapInst *to)
 {
 	int i;
 
@@ -949,7 +949,7 @@ Copy(ObjSurfSwapInst *from, ObjSurfSwapInst *to)
 }
 
 XCALL_(static LWError)
-Load(ObjSurfSwapInst *inst, const LWLoadState *ls)
+Load(ObjMeshSwapInst *inst, const LWLoadState *ls)
 {
 	XCALL_INIT;
 
@@ -962,7 +962,7 @@ Load(ObjSurfSwapInst *inst, const LWLoadState *ls)
 }
 
 XCALL_(static LWError)
-Save(ObjSurfSwapInst *inst, const LWSaveState *ss)
+Save(ObjMeshSwapInst *inst, const LWSaveState *ss)
 {
 	XCALL_INIT;
 
@@ -973,7 +973,7 @@ Save(ObjSurfSwapInst *inst, const LWSaveState *ss)
 }
 
 XCALL_(static void)
-Evaluate(ObjSurfSwapInst *inst, ObjReplacementAccess *oa)
+Evaluate(ObjMeshSwapInst *inst, ObjReplacementAccess *oa)
 {
 	int bestIdx;
 	const char *target;
@@ -1012,7 +1012,7 @@ Evaluate(ObjSurfSwapInst *inst, ObjReplacementAccess *oa)
  * Interface
  * ---------------------------------------------------------------- */
 
-static ObjSurfSwapInst *ui_inst;
+static ObjMeshSwapInst *ui_inst;
 static char           ui_buf[80];
 
 static int
@@ -1049,7 +1049,7 @@ XCALL_(static int)
 Interface(
 	long           version,
 	GlobalFunc    *global,
-	ObjSurfSwapInst *inst,
+	ObjMeshSwapInst *inst,
 	void          *serverData)
 {
 	LWPanelFuncs *panl;
@@ -1076,7 +1076,7 @@ Interface(
 		static LWValue ival = {LWT_INTEGER};
 		(void)ival;
 
-		pan = PAN_CREATE(panl, "ObjSurfSwap v" PLUGIN_VERSION " (c) D. Panokostas");
+		pan = PAN_CREATE(panl, "ObjMeshSwap v" PLUGIN_VERSION " (c) D. Panokostas");
 		if (!pan)
 			goto fallback;
 
@@ -1134,15 +1134,15 @@ fallback:
 		                   " replacement(s) for ");
 		str_append_bounded(infoBuf, sizeof(inst->messageBuf),
 		                   inst->baseName);
-		(*msg->info)("ObjSurfSwap", infoBuf);
+		(*msg->info)("ObjMeshSwap", infoBuf);
 	} else if (inst->basePath[0]) {
 		str_copy_bounded(infoBuf, sizeof(inst->messageBuf),
 		                 "No replacements for ");
 		str_append_bounded(infoBuf, sizeof(inst->messageBuf),
 		                   inst->baseName);
-		(*msg->info)("ObjSurfSwap", infoBuf);
+		(*msg->info)("ObjMeshSwap", infoBuf);
 	} else {
-		(*msg->info)("ObjSurfSwap",
+		(*msg->info)("ObjMeshSwap",
 		             "Preview a frame to detect files.");
 	}
 
@@ -1186,9 +1186,9 @@ Activate(
  * ---------------------------------------------------------------- */
 
 ServerRecord ServerDesc[] = {
-	{ "ObjReplacementHandler",   "ObjSurfSwap",
+	{ "ObjReplacementHandler",   "ObjMeshSwap",
 	  (ActivateFunc *)Activate },
-	{ "ObjReplacementInterface", "ObjSurfSwap",
+	{ "ObjReplacementInterface", "ObjMeshSwap",
 	  (ActivateFunc *)Interface },
 	{ 0 }
 };


### PR DESCRIPTION
## Summary
- Renames the surface-preserving object replacement plugin from `ObjSurfSwap` to `ObjMeshSwap` to better describe its function (mesh replacement while preserving the base object's surfaces).
- Updates the source file/directory (`src/objsurfswap/` → `src/objmeshswap/`), all in-source symbol/string references, panel title, info popup labels, handler/interface registration entries, and the cache file prefix.
- Updates `Makefile` targets, the plugin README, and the top-level README (table entry, build command, project tree).

Closes #13.

## Test plan
- [x] `./build.sh objmeshswap` builds cleanly and produces `build/objmeshswap.p`.
- [ ] Smoke-test the renamed plugin in LightWave: load a base object, attach **ObjMeshSwap** via Obj Rep Plug-ins, verify the panel title reads `ObjMeshSwap v0.9.2` and that the frame-based replacement still works (sidecar cache files now prefixed `ObjMeshSwapCache-`).